### PR TITLE
fix: video is not flipped around y axis anymore

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -81,7 +81,7 @@ mp_hands = mp.solutions.hands
 
 print("Current working directory:", os.getcwd())
 
-with open('src/data.json') as f:
+with open('data.json') as f:
     json_data = json.load(f)
     json_data = json_data["pages"]
 
@@ -96,7 +96,6 @@ with mp_hands.Hands(
     while cap.isOpened():
         success, frame = cap.read()
         # frame = cv2.flip(frame, 0)
-        frame = cv2.flip(frame, 1)
 
         if not success:
             print("Ignoring empty camera frame.")


### PR DESCRIPTION
When the camera is mirrored in y axis and thus the ArUco markers are also mirrored which breaks the code and makes the markers unrecognisable. Fixed this issue by removing the line flipping the camera on y axis.